### PR TITLE
Emit `rebalance` events to consumers by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function create(config, logger, settings) {
         // Default settings for the client. This uses the options we defined
         // before exposing all the settings available to rdkafka
         let clientOptions = {
+            'rebalance_cb': true,
             'group.id': group,
             'metadata.broker.list': config.brokers,
         };


### PR DESCRIPTION
In case you want this as a default.  Otherwise, reject this PR and require callers to enable via `rdkafka_options: {rebalance_cb: ...}}`.